### PR TITLE
Fixes negative scale values for Crop & Stretch

### DIFF
--- a/src/settings/Image.java
+++ b/src/settings/Image.java
@@ -214,7 +214,7 @@ public class Image extends Shutter {
 				{
 					o[0] = String.valueOf((int) Math.round((float) oh * ir));
 				}
-        		else
+        		else if (o[1].toString().equals("1")) // Don't overwrite or negative scales won't work right for "Stretch"
         		{
         			o[1] = String.valueOf((int) Math.round((float) ow / ir));
         		}
@@ -253,6 +253,12 @@ public class Image extends Shutter {
 			        		else
 			        			filterComplex += "scale="+o[0]+":-1";
 			        	}
+						// Negative scale makes sure that the auto set dimension is divisible, fixes "Crop"
+						// ex: -2:480 means 480h with the closes width matching the aspect
+						else if (comboResolution.getSelectedItem().toString().contains("-")) {
+							o = comboResolution.getSelectedItem().toString().split(":");
+							filterComplex += "scale=" + o[0] + ":" + o[1];
+						}
 			        	else
 			        	{
 				            o = comboResolution.getSelectedItem().toString().split(":");

--- a/src/settings/Image.java
+++ b/src/settings/Image.java
@@ -214,7 +214,8 @@ public class Image extends Shutter {
 				{
 					o[0] = String.valueOf((int) Math.round((float) oh * ir));
 				}
-        		else if (o[1].toString().equals("1")) // Don't overwrite or negative scales won't work right for "Stretch"
+				// Don't overwrite when negative scale or they won't work right for "Stretch"
+        		else if (!(o[0].toString().contains("-") || o[1].toString().contains("-")))
         		{
         			o[1] = String.valueOf((int) Math.round((float) ow / ir));
         		}


### PR DESCRIPTION
Values were being converted to decimals and multiplied instead of directly being used when a negative value (using -) was used for scale.

See: https://www.reddit.com/r/shutterencoder/comments/1awvnle/scaling_feature_request_allow_negative_numbers/ 
for the original issue.