### PR TITLE
Security: FFmpeg argument injection via unescaped file names in command string builder

### DIFF
--- a/src/settings/AudioSettings.java
+++ b/src/settings/AudioSettings.java
@@ -46,7 +46,8 @@ public class AudioSettings extends Shutter {
 			
 			if (audioName.toString().contains(videoName.toString()) && audioName.toString().equals(videoName.toString()) == false) //L'audio contient le nom du fichier vidéo
 				{
-					audioFiles += " -i " + '"' + list.getElementAt(i2) + '"' + " ";
+					String audioPath = list.getElementAt(i2).replace("\\", "\\\\").replace("\"", "\\\"");
+					audioFiles += " -i " + '"' + audioPath + '"' + " ";
 					channels ++;
 				}
 		}


### PR DESCRIPTION
Hi there! 👋

While going through the codebase, I noticed a minor opportunity for improvement regarding `src/settings/AudioSettings.java`.

**Context:**
`setAudioFiles()` appends input file paths directly into a command string: `audioFiles += " -i " + '"' + list.getElementAt(i2) + '"' + " ";`. A crafted filename containing quotes or argument separators can break out of the intended argument and inject extra ffmpeg flags (e.g., overwrite outputs, alter mappings, read unintended files), if this string is later executed as a raw command.


**Proposed fix:**
Replace string-based command construction with argument lists. Return `List<String>` instead of `String` and append each token separately:
`List<String> audioArgs = new ArrayList<>();` `audioArgs.add("-i");` `audioArgs.add(list.getElementAt(i2));`
If refactor is not immediately possible, at minimum escape embedded quotes in file names before concatenation: `path.replace("\\", "\\\\").replace("\"", "\\\"")`.

**Files touched:**
- `src/settings/AudioSettings.java` (modified)

*(Note: Tested the changes locally to ensure everything works as expected. Let me know if you need any adjustments, happy to help!)*

—
**NamNV**
📍 Hanoi, Vietnam
📧 nam.nv205106@gmail.com
