### PR TITLE
Close InputStreamReader in checkHWaccel

### DIFF
--- a/src/shutterencoder/library/FFMPEG.java
+++ b/src/shutterencoder/library/FFMPEG.java
@@ -1263,21 +1263,22 @@ public static StringBuilder errorLog = new StringBuilder();
 
 			if (cmd.contains("-hwaccels"))
 			{
-				InputStreamReader isr = new InputStreamReader(process.getInputStream());
-		        BufferedReader br = new BufferedReader(isr);
+				try (InputStreamReader isr = new InputStreamReader(process.getInputStream())) {
+					BufferedReader br = new BufferedReader(isr);
 		        
-		        hwaccels.append("auto" + System.lineSeparator());
+					hwaccels.append("auto" + System.lineSeparator());
 		        
-		        while ((line = br.readLine()) != null) 
-		        {				        	
+					while ((line = br.readLine()) != null) 
+					{				        	
 		        	
-		        	if (line.contains("Hardware acceleration methods") == false && line.equals("") == false && line != null)
-		        	{
-		        		hwaccels.append(line + System.lineSeparator());
-		        	}
-		        }
+					if (line.contains("Hardware acceleration methods") == false && line.equals("") == false && line != null)
+					{
+					hwaccels.append(line + System.lineSeparator());
+					}
+					}
 		        
-		        hwaccels.append(language.getProperty("aucun"));				        
+					hwaccels.append(language.getProperty("aucun"));				        
+				}
 		    }
 			else
 			{


### PR DESCRIPTION
Kept looking at checkHWaccel in src/shutterencoder/library/FFMPEG.java and wanted to flag something: The resource opened there can leak if checkHWaccel exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.