### PR TITLE
Fix Linux post-encode freeze and PDF page preview compile error (20.3)

### DIFF
--- a/src/shutterencoder/functions/utils/FunctionUtils.java
+++ b/src/shutterencoder/functions/utils/FunctionUtils.java
@@ -22,7 +22,6 @@ package shutterencoder.functions.utils;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Cursor;
-import java.awt.Desktop;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -1467,10 +1466,7 @@ public class FunctionUtils extends Shutter {
 										} catch (Exception e2) {
 										}
 									} else if (System.getProperty("os.name").contains("Linux")) {
-										try {
-											Desktop.getDesktop().open(fileOut);
-										} catch (Exception e2) {
-										}
+										Utils.open(fileOut);
 									} else // Windows
 									{
 										try {
@@ -2058,11 +2054,7 @@ public class FunctionUtils extends Shutter {
 		//Open the folder
 		if (caseOpenFolderAtEnd1.isSelected() && comboFonctions.getSelectedItem().equals(language.getProperty("functionMerge")) == false && cancelled == false && FFMPEG.error == false)
 		{
-			try {
-				Desktop.getDesktop().open(new File(output));
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
+			Utils.open(new File(output));
 		}		
 		
 		//Delete file

--- a/src/shutterencoder/library/PDF.java
+++ b/src/shutterencoder/library/PDF.java
@@ -21,6 +21,7 @@ package shutterencoder.library;
 
 import java.awt.Cursor;
 import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferByte;
 import java.io.File;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -28,7 +29,8 @@ import org.apache.pdfbox.rendering.ImageType;
 import org.apache.pdfbox.rendering.PDFRenderer;
 
 import shutterencoder.ui.main.Shutter;
-import shutterencoder.ui.videoplayer.VideoPlayer;
+import shutterencoder.ui.videoplayer.VideoPlayerCore;
+import shutterencoder.ui.videoplayer.VideoPlayerUtils;
 
 public class PDF extends Shutter {
 	
@@ -58,17 +60,17 @@ public static int pagesCount = 1;
 					
 					pagesCount = document.getNumberOfPages();
 					
-					BufferedImage converted = new BufferedImage(VideoPlayer.player.getWidth(), VideoPlayer.player.getHeight(), BufferedImage.TYPE_3BYTE_BGR);
-					converted.getGraphics().drawImage(pdfRenderer.renderImageWithDPI(pageNumber, 300), 0, 0, VideoPlayer.player.getWidth(), VideoPlayer.player.getHeight(), null);
+					BufferedImage converted = new BufferedImage(VideoPlayerCore.player.getWidth(), VideoPlayerCore.player.getHeight(), BufferedImage.TYPE_3BYTE_BGR);
+					converted.getGraphics().drawImage(pdfRenderer.renderImageWithDPI(pageNumber, 300), 0, 0, VideoPlayerCore.player.getWidth(), VideoPlayerCore.player.getHeight(), null);
 					
-					VideoPlayer.preview = converted;								
+					VideoPlayerCore.preview = ((DataBufferByte) converted.getRaster().getDataBuffer()).getData();
 					
 					document.close();
 					
 					FFPROBE.interlaced = null;						
-					FFPROBE.analyzedMedia = VideoPlayer.videoPath;	
+					FFPROBE.analyzedMedia = VideoPlayerCore.videoPath;	
 					
-					VideoPlayer.setInfo();
+					VideoPlayerUtils.setInfo();
 				
 				} catch (Exception e) {
 					error = true;					

--- a/src/shutterencoder/utils/Utils.java
+++ b/src/shutterencoder/utils/Utils.java
@@ -22,6 +22,7 @@ package shutterencoder.utils;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Cursor;
+import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.Insets;
 import java.awt.MouseInfo;
@@ -2806,5 +2807,27 @@ public class Utils extends Shutter {
 		}
 		else
 			System.exit(0);	
+	}
+
+	/**
+	 * Opens a file or folder with the default application. On Linux the opener is
+	 * spawned detached: {@code java.awt.Desktop.open()} can block forever on
+	 * Wayland/X11 (it holds the AWT lock waiting for the launched file manager),
+	 * which freezes the whole UI.
+	 */
+	public static void open(File file) {
+		try {
+			if (System.getProperty("os.name").contains("Linux"))
+			{
+				// Detached spawn: returns immediately, touches no AWT/X11 lock
+				new ProcessBuilder("gio", "open", file.getAbsolutePath())
+						.redirectOutput(ProcessBuilder.Redirect.DISCARD)
+						.redirectError(ProcessBuilder.Redirect.DISCARD).start();
+			}
+			else
+				Desktop.getDesktop().open(file);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
 	}
 }


### PR DESCRIPTION
Two small, verified fixes for the 20.3 tree.

## Fix 1 — Post-encode freeze on Linux with "Open folder at end"

**Symptom:** after each completed file the app freezes at ~70–80% progress with a spinning cursor and cannot be closed, even though the encode finishes and the output files are written correctly. Minimizing/restoring the window then shows a grey (unpainted) UI.

**Root cause:** `FunctionUtils.cleanFunction` (and the subtitle-copy thread) call `java.awt.Desktop.open()` on the encode worker thread. On Linux, `Desktop.open` → `XDesktopPeer.gnome_url_show` blocks forever — it spawns the file manager (`gio open`) and never returns — while holding the global AWT X11 lock (`XToolkit.awtLock`). The wedged worker never releases the lock, so the X event pump is starved: no clicks, no close, no repaint.

**Fix:** add `Utils.open(File)`, which on Linux spawns `gio open` **detached** (`ProcessBuilder` with DISCARD redirects — returns immediately, touches no AWT/X11 lock) and falls back to `Desktop.open` elsewhere. The two auto-run completion paths now use it.

**Verification:** 60 s DNxHR encode with "Open folder at end" enabled — completes cleanly, app stays responsive and closes normally (previously stuck forever, needed `kill -9`). Reproduced and fixed on KDE Plasma / Wayland (XWayland), JDK 26.

## Fix 2 — PDF page preview: broken import (20.3 does not compile)

**Symptom:** `src/shutterencoder/library/PDF.java` imports `shutterencoder.ui.videoplayer.VideoPlayer`, but that class was renamed to `VideoPlayerCore` and no longer exists in the tree — the project does not compile.

**Fix:** update PDF.java to `VideoPlayerCore`, set `preview` from the rendered `BufferedImage` raster (`DataBufferByte`) to match the new `byte[]` field, and use `VideoPlayerUtils.setInfo()`.

**Verification:** full compile of all sources passes (`javac` with `src/libs`).

---
Both commits are cherry-picks of the identical changes verified on a local source build. Files use CRLF line endings (`core.whitespace cr-at-eol` for `git diff --check`).